### PR TITLE
chore: reschedule CIT CTF 2026 posts and make English the default

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,8 +7,8 @@ import rehypeMermaid from 'rehype-mermaid';
 export default defineConfig({
   site: 'https://jackpan.me',
   i18n: {
-    defaultLocale: 'zh',
-    locales: ['zh', 'en'],
+    defaultLocale: 'en',
+    locales: ['en', 'zh'],
     routing: {
       prefixDefaultLocale: false,
       redirectToDefaultLocale: false,
@@ -18,8 +18,8 @@ export default defineConfig({
     mdx(),
     sitemap({
       i18n: {
-        defaultLocale: 'zh',
-        locales: { zh: 'zh-CN', en: 'en-US' },
+        defaultLocale: 'en',
+        locales: { en: 'en-US', zh: 'zh-CN' },
       },
     }),
     tailwind({ applyBaseStyles: false }),

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ import { t } from '../i18n/ui';
 
 interface Props { lang: Lang; }
 const { lang } = Astro.props;
-const rssHref = lang === 'zh' ? '/rss.xml' : '/en/rss.xml';
+const rssHref = lang === 'en' ? '/rss.xml' : '/zh/rss.xml';
 ---
 
 <footer class="border-t border-[var(--border)] mt-16">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -9,5 +9,5 @@ export const SOCIAL = {
 };
 
 export type Lang = 'zh' | 'en';
-export const LANGS: Lang[] = ['zh', 'en'];
-export const DEFAULT_LANG: Lang = 'zh';
+export const LANGS: Lang[] = ['en', 'zh'];
+export const DEFAULT_LANG: Lang = 'en';

--- a/src/content/posts/en/cit-ctf-2026-baby-exponent.mdx
+++ b/src/content/posts/en/cit-ctf-2026-baby-exponent.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Baby Exponent: the most textbook RSA e=3"
 description: Public exponent e=3, plaintext small enough that m³ never overflowed the modulus. Integer cube root and done.
-pubDate: 2026-05-07
+pubDate: 2026-04-25
 tags: [CTF, cit-ctf-2026, crypto, rsa]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/en/cit-ctf-2026-debug-disaster.mdx
+++ b/src/content/posts/en/cit-ctf-2026-debug-disaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Debug Disaster: a leaky debug page and a forgotten route"
 description: Flask debug=True leaks more than tracebacks — it leaked the source code of a forgotten route that dumps .env in cleartext.
-pubDate: 2026-05-10
+pubDate: 2026-04-26
 tags: [CTF, cit-ctf-2026, web, flask]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/en/cit-ctf-2026-dog-barking.mdx
+++ b/src/content/posts/en/cit-ctf-2026-dog-barking.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Dog Barking: three bark durations, one custom encoding"
 description: 78 seconds of dog barks. Three distinct bark durations encode bit 0, bit 1, and the byte separator. Not Morse — a custom code.
-pubDate: 2026-05-06
+pubDate: 2026-04-25
 tags: [CTF, cit-ctf-2026, misc, audio]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/en/cit-ctf-2026-mass-assignment.mdx
+++ b/src/content/posts/en/cit-ctf-2026-mass-assignment.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · A Massive Problem: mass assignment via dict.update"
 description: The challenge name spells it out. At register time, record.update(incoming) lets the role field in the request body overwrite the hard-coded default.
-pubDate: 2026-05-09
+pubDate: 2026-04-26
 tags: [CTF, cit-ctf-2026, web, flask]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/en/cit-ctf-2026-overview.mdx
+++ b/src/content/posts/en/cit-ctf-2026-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026: a few writeups worth keeping"
 description: I played CIT CTF 2026 over the holiday — this is the index post for a short series of writeups covering Web, Crypto and Misc challenges.
-pubDate: 2026-05-11
+pubDate: 2026-04-26
 tags: [CTF, cit-ctf-2026, web, crypto, misc]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/en/cit-ctf-2026-server-components.mdx
+++ b/src/content/posts/en/cit-ctf-2026-server-components.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Server Components: RCE via Next.js 15 RSC deserialization"
 description: package.json pins next@15.0.4 — squarely inside the window for this year's React Server Components deserialization RCE.
-pubDate: 2026-05-08
+pubDate: 2026-04-25
 tags: [CTF, cit-ctf-2026, web, nextjs, cve]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/zh/cit-ctf-2026-baby-exponent.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-baby-exponent.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Baby Exponent：e=3 的最朴素 RSA 利用"
 description: 公开指数 e=3，明文小到 m³ 没溢出 modulus，直接整数开三次方就能拿到。
-pubDate: 2026-05-07
+pubDate: 2026-04-25
 tags: [CTF, cit-ctf-2026, crypto, rsa]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/zh/cit-ctf-2026-debug-disaster.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-debug-disaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Debug Disaster：调试页带出的 .env 路由"
 description: Flask debug=True 暴露的不只是 traceback，把 .env 原文吐出来的路由也跟着一起进来了。
-pubDate: 2026-05-10
+pubDate: 2026-04-26
 tags: [CTF, cit-ctf-2026, web, flask]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/zh/cit-ctf-2026-dog-barking.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-dog-barking.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Dog Barking：三种长度的狗叫"
 description: 一段 78 秒的狗叫音频，三种 bark 时长分别对应比特 0、比特 1 和字节分隔符。不是摩斯，是自创编码。
-pubDate: 2026-05-06
+pubDate: 2026-04-25
 tags: [CTF, cit-ctf-2026, misc, audio]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/zh/cit-ctf-2026-mass-assignment.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-mass-assignment.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · A Massive Problem：dict.update 撑起的越权"
 description: 题目名直接拼出 Mass Assignment。register 时 record.update(incoming) 让请求体里的 role 字段把服务端写死的默认值盖掉。
-pubDate: 2026-05-09
+pubDate: 2026-04-26
 tags: [CTF, cit-ctf-2026, web, flask]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/zh/cit-ctf-2026-overview.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026：几道印象深的题"
 description: 五一假期跟着打了 CIT CTF 2026，把 Web / Crypto / Misc 几道题的解题思路整理成系列。这篇是入口。
-pubDate: 2026-05-11
+pubDate: 2026-04-26
 tags: [CTF, cit-ctf-2026, web, crypto, misc]
 series: CIT CTF 2026
 ---

--- a/src/content/posts/zh/cit-ctf-2026-server-components.mdx
+++ b/src/content/posts/zh/cit-ctf-2026-server-components.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CIT CTF 2026 · Server Components：Next.js 15 RSC 反序列化 RCE"
 description: 附件里 package.json 钉死 next@15.0.4，刚好命中今年披露的 RSC 反序列化漏洞。
-pubDate: 2026-05-08
+pubDate: 2026-04-25
 tags: [CTF, cit-ctf-2026, web, nextjs, cve]
 series: CIT CTF 2026
 ---

--- a/src/i18n/posts.ts
+++ b/src/i18n/posts.ts
@@ -30,5 +30,5 @@ export async function findTranslation(post: Post): Promise<Post | null> {
 export function postUrl(post: Post): string {
   const lang = postLang(post);
   const slug = shortSlug(post);
-  return lang === 'zh' ? '/posts/' + slug + '/' : '/en/posts/' + slug + '/';
+  return lang === 'en' ? '/posts/' + slug + '/' : '/zh/posts/' + slug + '/';
 }

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -64,7 +64,7 @@ export const ui = {
 export type UIKey = keyof typeof ui['zh'];
 
 export function t(lang: Lang, key: UIKey, vars?: Record<string, string | number>): string {
-  let s: string = ui[lang][key] ?? ui.zh[key];
+  let s: string = ui[lang][key] ?? ui.en[key];
   if (vars) {
     for (const [k, v] of Object.entries(vars)) {
       s = s.replace('{' + k + '}', String(v));

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,8 +1,8 @@
 import { type Lang, DEFAULT_LANG } from '../consts';
 
 export function getLangFromPath(pathname: string): Lang {
-  if (pathname.startsWith('/en/') || pathname === '/en') return 'en';
-  return 'zh';
+  if (pathname.startsWith('/zh/') || pathname === '/zh') return 'zh';
+  return 'en';
 }
 
 export function localizedPath(path: string, lang: Lang): string {
@@ -10,16 +10,16 @@ export function localizedPath(path: string, lang: Lang): string {
   if (lang === DEFAULT_LANG) {
     return clean === '' ? '/' : clean + '/';
   }
-  return clean === '' ? '/en/' : '/en' + clean + '/';
+  return clean === '' ? '/zh/' : '/zh' + clean + '/';
 }
 
 export function getAlternatePath(pathname: string): { lang: Lang; path: string } {
   const currentLang = getLangFromPath(pathname);
-  if (currentLang === 'zh') {
-    const path = pathname === '/' ? '/en/' : '/en' + pathname;
-    return { lang: 'en', path };
+  if (currentLang === 'en') {
+    const path = pathname === '/' ? '/zh/' : '/zh' + pathname;
+    return { lang: 'zh', path };
   } else {
-    const stripped = pathname.replace(/^\/en/, '') || '/';
-    return { lang: 'zh', path: stripped };
+    const stripped = pathname.replace(/^\/zh/, '') || '/';
+    return { lang: 'en', path: stripped };
   }
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,7 +39,7 @@ const htmlLang = t(lang, 'site.locale');
       rel="alternate"
       type="application/rss+xml"
       title={siteTitle}
-      href={lang === 'zh' ? '/rss.xml' : '/en/rss.xml'}
+      href={lang === 'en' ? '/rss.xml' : '/zh/rss.xml'}
     />
     <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -26,7 +26,7 @@ const fmt = (d: Date) => d.toLocaleDateString(locale, {
   month: lang === 'zh' ? 'long' : 'short',
   day: 'numeric',
 });
-const tagsBase = lang === 'zh' ? '/tags' : '/en/tags';
+const tagsBase = lang === 'en' ? '/tags' : '/zh/tags';
 ---
 
 <BaseLayout lang={lang} title={title} description={description}>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,19 +2,20 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { t } from '../i18n/ui';
 
-const lang = 'zh';
+const lang = 'en';
 ---
 
 <BaseLayout lang={lang} title={t(lang, 'about.title')}>
   <article class="prose dark:prose-invert max-w-none">
-    <h1>关于</h1>
+    <h1>About</h1>
     <p>
-      你好，我是潘杰，目前在数据平台领域做研发工作。
+      Hi, I'm Jack Pan, currently working on data platform engineering.
     </p>
     <p>
-      这个博客主要记录我在数据工程、计算机视觉数据流水线、以及一些工程化实践方面的探索。
+      This blog is where I write about data engineering, computer vision data pipelines,
+      and general engineering practice.
     </p>
-    <h2>联系</h2>
+    <h2>Contact</h2>
     <ul>
       <li>Email: <a href="mailto:i@jackpan.me">i@jackpan.me</a></li>
       <li>GitHub: <a href="https://github.com/jack0pan">@jack0pan</a></li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import { getPostsByLang } from '../i18n/posts';
 import { t } from '../i18n/ui';
 import { SOCIAL } from '../consts';
 
-const lang = 'zh';
+const lang = 'en';
 const posts = (await getPostsByLang(lang)).slice(0, 5);
 
 const topics = [
@@ -25,8 +25,8 @@ const githubHandle = SOCIAL.github.replace('https://github.com/', '');
   <section class="font-mono text-sm leading-relaxed mb-10">
     <p class="text-[var(--accent)]">$ whoami</p>
     <div class="mt-3 pl-4 border-l border-[var(--border)] text-[var(--fg)]">
-      潘杰（Jack Pan）· 数据平台工程师。业余时间折腾计算机视觉数据流水线。
-      这里记录「真的跑过」的东西，一周一篇的节奏。
+      Jack Pan · data platform engineer. On the side I tinker with computer vision data pipelines.
+      Notes here are about things I've actually shipped, roughly one post a week.
     </div>
   </section>
 

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -4,7 +4,7 @@ import readingTime from 'reading-time';
 import { getPostsByLang, shortSlug, findTranslation } from '../../i18n/posts';
 
 export async function getStaticPaths() {
-  const posts = await getPostsByLang('zh');
+  const posts = await getPostsByLang('en');
   return posts.map(post => ({
     params: { slug: shortSlug(post) },
     props: { post },
@@ -13,12 +13,12 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await post.render();
-const minutes = Math.max(1, Math.ceil(readingTime(post.body, { wordsPerMinute: 300 }).minutes));
+const minutes = Math.max(1, Math.ceil(readingTime(post.body, { wordsPerMinute: 250 }).minutes));
 const translation = await findTranslation(post);
 ---
 
 <PostLayout
-  lang="zh"
+  lang="en"
   title={post.data.title}
   description={post.data.description}
   pubDate={post.data.pubDate}

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -4,7 +4,7 @@ import PostCard from '../../components/PostCard.astro';
 import { getPostsByLang } from '../../i18n/posts';
 import { t } from '../../i18n/ui';
 
-const lang = 'zh';
+const lang = 'en';
 const posts = await getPostsByLang(lang);
 
 const byYear = posts.reduce((acc, post) => {

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -4,7 +4,7 @@ import { getPostsByLang, postUrl } from '../i18n/posts';
 import { t } from '../i18n/ui';
 
 export async function GET(context: APIContext) {
-  const lang = 'zh';
+  const lang = 'en';
   const posts = await getPostsByLang(lang);
   return rss({
     title: t(lang, 'site.title'),

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -5,7 +5,7 @@ import { getPostsByLang } from '../../i18n/posts';
 import { t } from '../../i18n/ui';
 
 export async function getStaticPaths() {
-  const posts = await getPostsByLang('zh');
+  const posts = await getPostsByLang('en');
   const tags = [...new Set(posts.flatMap(p => p.data.tags))];
   return tags.map(tag => ({
     params: { tag },
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 }
 
 const { tag, posts } = Astro.props;
-const lang = 'zh';
+const lang = 'en';
 ---
 
 <BaseLayout lang={lang} title={`#${tag}`}>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getPostsByLang } from '../../i18n/posts';
 import { t } from '../../i18n/ui';
 
-const lang = 'zh';
+const lang = 'en';
 const posts = await getPostsByLang(lang);
 const tagCount = new Map<string, number>();
 posts.forEach(p => p.data.tags.forEach(tag => tagCount.set(tag, (tagCount.get(tag) || 0) + 1)));

--- a/src/pages/zh/about.astro
+++ b/src/pages/zh/about.astro
@@ -2,20 +2,19 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { t } from '../../i18n/ui';
 
-const lang = 'en';
+const lang = 'zh';
 ---
 
 <BaseLayout lang={lang} title={t(lang, 'about.title')}>
   <article class="prose dark:prose-invert max-w-none">
-    <h1>About</h1>
+    <h1>关于</h1>
     <p>
-      Hi, I'm Jack Pan, currently working on data platform engineering.
+      你好，我是潘杰，目前在数据平台领域做研发工作。
     </p>
     <p>
-      This blog is where I write about data engineering, computer vision data pipelines,
-      and general engineering practice.
+      这个博客主要记录我在数据工程、计算机视觉数据流水线、以及一些工程化实践方面的探索。
     </p>
-    <h2>Contact</h2>
+    <h2>联系</h2>
     <ul>
       <li>Email: <a href="mailto:i@jackpan.me">i@jackpan.me</a></li>
       <li>GitHub: <a href="https://github.com/jack0pan">@jack0pan</a></li>

--- a/src/pages/zh/index.astro
+++ b/src/pages/zh/index.astro
@@ -5,7 +5,7 @@ import { getPostsByLang } from '../../i18n/posts';
 import { t } from '../../i18n/ui';
 import { SOCIAL } from '../../consts';
 
-const lang = 'en';
+const lang = 'zh';
 const posts = (await getPostsByLang(lang)).slice(0, 5);
 
 const topics = [
@@ -25,8 +25,8 @@ const githubHandle = SOCIAL.github.replace('https://github.com/', '');
   <section class="font-mono text-sm leading-relaxed mb-10">
     <p class="text-[var(--accent)]">$ whoami</p>
     <div class="mt-3 pl-4 border-l border-[var(--border)] text-[var(--fg)]">
-      Jack Pan · data platform engineer. On the side I tinker with computer vision data pipelines.
-      Notes here are about things I've actually shipped, roughly one post a week.
+      潘杰（Jack Pan）· 数据平台工程师。业余时间折腾计算机视觉数据流水线。
+      这里记录「真的跑过」的东西，一周一篇的节奏。
     </div>
   </section>
 
@@ -45,7 +45,7 @@ const githubHandle = SOCIAL.github.replace('https://github.com/', '');
   </section>
 
   <div class="mb-10 font-mono text-sm">
-    <a href="/en/posts/" class="text-[var(--accent)] hover:underline">
+    <a href="/zh/posts/" class="text-[var(--accent)] hover:underline">
       {t(lang, 'home.viewAll')}
     </a>
   </div>
@@ -58,7 +58,7 @@ const githubHandle = SOCIAL.github.replace('https://github.com/', '');
       <dt>email</dt>
       <dd><a class="hover:text-[var(--accent)] hover:underline" href={`mailto:${SOCIAL.email}`}>{SOCIAL.email}</a></dd>
       <dt>rss</dt>
-      <dd><a class="hover:text-[var(--accent)] hover:underline" href="/en/rss.xml">/en/rss.xml</a></dd>
+      <dd><a class="hover:text-[var(--accent)] hover:underline" href="/zh/rss.xml">/zh/rss.xml</a></dd>
     </dl>
   </section>
 </BaseLayout>

--- a/src/pages/zh/posts/[slug].astro
+++ b/src/pages/zh/posts/[slug].astro
@@ -4,7 +4,7 @@ import readingTime from 'reading-time';
 import { getPostsByLang, shortSlug, findTranslation } from '../../../i18n/posts';
 
 export async function getStaticPaths() {
-  const posts = await getPostsByLang('en');
+  const posts = await getPostsByLang('zh');
   return posts.map(post => ({
     params: { slug: shortSlug(post) },
     props: { post },
@@ -13,12 +13,12 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await post.render();
-const minutes = Math.max(1, Math.ceil(readingTime(post.body, { wordsPerMinute: 250 }).minutes));
+const minutes = Math.max(1, Math.ceil(readingTime(post.body, { wordsPerMinute: 300 }).minutes));
 const translation = await findTranslation(post);
 ---
 
 <PostLayout
-  lang="en"
+  lang="zh"
   title={post.data.title}
   description={post.data.description}
   pubDate={post.data.pubDate}

--- a/src/pages/zh/posts/index.astro
+++ b/src/pages/zh/posts/index.astro
@@ -4,7 +4,7 @@ import PostCard from '../../../components/PostCard.astro';
 import { getPostsByLang } from '../../../i18n/posts';
 import { t } from '../../../i18n/ui';
 
-const lang = 'en';
+const lang = 'zh';
 const posts = await getPostsByLang(lang);
 
 const byYear = posts.reduce((acc, post) => {

--- a/src/pages/zh/rss.xml.ts
+++ b/src/pages/zh/rss.xml.ts
@@ -4,7 +4,7 @@ import { getPostsByLang, postUrl } from '../../i18n/posts';
 import { t } from '../../i18n/ui';
 
 export async function GET(context: APIContext) {
-  const lang = 'en';
+  const lang = 'zh';
   const posts = await getPostsByLang(lang);
   return rss({
     title: t(lang, 'site.title'),

--- a/src/pages/zh/tags/[tag].astro
+++ b/src/pages/zh/tags/[tag].astro
@@ -5,7 +5,7 @@ import { getPostsByLang } from '../../../i18n/posts';
 import { t } from '../../../i18n/ui';
 
 export async function getStaticPaths() {
-  const posts = await getPostsByLang('en');
+  const posts = await getPostsByLang('zh');
   const tags = [...new Set(posts.flatMap(p => p.data.tags))];
   return tags.map(tag => ({
     params: { tag },
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 }
 
 const { tag, posts } = Astro.props;
-const lang = 'en';
+const lang = 'zh';
 ---
 
 <BaseLayout lang={lang} title={`#${tag}`}>

--- a/src/pages/zh/tags/index.astro
+++ b/src/pages/zh/tags/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { getPostsByLang } from '../../../i18n/posts';
 import { t } from '../../../i18n/ui';
 
-const lang = 'en';
+const lang = 'zh';
 const posts = await getPostsByLang(lang);
 const tagCount = new Map<string, number>();
 posts.forEach(p => p.data.tags.forEach(tag => tagCount.set(tag, (tagCount.get(tag) || 0) + 1)));
@@ -15,7 +15,7 @@ const tags = [...tagCount.entries()].sort((a, b) => b[1] - a[1]);
   <div class="flex flex-wrap gap-3">
     {tags.map(([tag, count]) => (
       <a
-        href={`/en/tags/${tag}/`}
+        href={`/zh/tags/${tag}/`}
         class="px-3 py-1.5 rounded border border-[var(--border)] text-sm hover:border-[var(--accent)] hover:text-[var(--accent)]"
       >
         {tag} <span class="text-[var(--muted)]">{count}</span>


### PR DESCRIPTION
## Summary

- Reschedule the CIT CTF 2026 writeups to the weekend after the event (2026-04-25/26). The CTF ran Apr 17–19, so the previous May dates were inconsistent with the timeline. Posts are split 3/3 across Saturday/Sunday in their original publication order, with the overview landing last on Sunday.
- Make English the default locale: `/` now serves English and `/zh/` serves Chinese. `src/pages/en/*` content was moved to the top level and the original Chinese pages now live under `src/pages/zh/*`. `defaultLocale`, `DEFAULT_LANG`, `i18n/utils.ts`, `postUrl`, sitemap config, and the `lang`-conditional snippets in layouts/components were all flipped to match.

## Test plan

- [x] `pnpm build` succeeds — 90 pages built, `<html lang>` is `en-US` at `/` and `zh-CN` under `/zh/`.
- [x] Spot-checked rendered dates: CTF posts show 2026-04-25 / 2026-04-26 in both `dist/posts/` and `dist/zh/posts/`.
- [ ] Manually walk the rendered site (nav links, language switcher, RSS hrefs, tag pages) once deployed to a preview.

https://claude.ai/code/session_01H9dPRNVCRAVfbarJ4P3VRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9dPRNVCRAVfbarJ4P3VRt)_